### PR TITLE
manifests/meshnet: sync to hardened drivenets fork v0.5.0-dn

### DIFF
--- a/manifests/meshnet/grpc/manifest.yaml
+++ b/manifests/meshnet/grpc/manifest.yaml
@@ -221,13 +221,31 @@ metadata:
     app: meshnet
   name: meshnet-clusterrole
 rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list", "watch"]
 - apiGroups:
   - networkop.co.uk
   resources:
   - topologies
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - networkop.co.uk
+  resources:
   - gwirekobjs
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
 - apiGroups:
   - networkop.co.uk
   resources:
@@ -235,7 +253,9 @@ rules:
   - gwirekobjs/spec
   - gwirekobjs/status
   verbs:
-  - '*'
+  - get
+  - update
+  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -293,15 +313,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: us-west1-docker.pkg.dev/kne-external/kne/networkop/meshnet:v0.3.2
+        image: public.ecr.aws/drivenets/meshnet-cni:v0.5.0-dn
         imagePullPolicy: IfNotPresent
         name: meshnet
         resources:
           limits:
-            memory: 512Mi
+            cpu: "2"
+            memory: 10G
           requests:
-            cpu: 50m
-            memory: 256Mi
+            cpu: 200m
+            memory: 1G
         securityContext:
           privileged: true
         volumeMounts:
@@ -312,7 +333,6 @@ spec:
         - mountPath: /var/run/netns
           mountPropagation: Bidirectional
           name: var-run-netns
-      hostIPC: true
       hostNetwork: true
       hostPID: true
       nodeSelector:

--- a/manifests/meshnet/vxlan/manifest.yaml
+++ b/manifests/meshnet/vxlan/manifest.yaml
@@ -221,13 +221,31 @@ metadata:
     app: meshnet
   name: meshnet-clusterrole
 rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list", "watch"]
 - apiGroups:
   - networkop.co.uk
   resources:
   - topologies
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - networkop.co.uk
+  resources:
   - gwirekobjs
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
 - apiGroups:
   - networkop.co.uk
   resources:
@@ -235,7 +253,9 @@ rules:
   - gwirekobjs/spec
   - gwirekobjs/status
   verbs:
-  - '*'
+  - get
+  - update
+  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -293,15 +313,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: us-west1-docker.pkg.dev/kne-external/kne/networkop/meshnet:v0.3.2
+        image: public.ecr.aws/drivenets/meshnet-cni:v0.5.0-dn
         imagePullPolicy: IfNotPresent
         name: meshnet
         resources:
           limits:
-            memory: 512Mi
+            cpu: "2"
+            memory: 10G
           requests:
-            cpu: 50m
-            memory: 256Mi
+            cpu: 200m
+            memory: 1G
         securityContext:
           privileged: true
         volumeMounts:
@@ -312,7 +333,6 @@ spec:
         - mountPath: /var/run/netns
           mountPropagation: Bidirectional
           name: var-run-netns
-      hostIPC: true
       hostNetwork: true
       hostPID: true
       nodeSelector:


### PR DESCRIPTION
## Summary

Swap the bundled meshnet manifest (grpc + vxlan) from upstream
`networkop/meshnet:v0.3.2` to `public.ecr.aws/drivenets/meshnet-cni:v0.5.0-dn`,
the hardened drivenets fork from [msupinodn/meshnet-cni#2](https://github.com/msupinodn/meshnet-cni/pull/2).

Carries the matching RBAC narrowing and the new `nodes get/list/watch`
rule the daemon needs for `validatePeerNodeIP` (peer-IP SSRF mitigation).

## Why this lives in two PRs

The source of truth for the meshnet manifest is `msupinodn/meshnet-cni`
(next to the code). This repo carries a copy under
`manifests/meshnet/grpc/manifest.yaml` because it bundles its own
installer like upstream `openconfig/kne`. GitHub can't make a single PR
span two repos, so this is the mirror commit.

## Install URL after merge

```
kubectl apply -f https://raw.githubusercontent.com/drivenets/kne/refs/heads/main/manifests/meshnet/grpc/manifest.yaml
```

i.e. swap `openconfig/` -> `drivenets/` in the URL you had before.

## Test plan

- [x] Applied locally on dev cluster against the previously-installed
      upstream v0.3.2 - clean rollout, no RBAC errors, sitea topology
      comes up with meshnet-wired links (eno0/eno1) inside both pods.
- [x] Daemon log shows no `forbidden`/`unauthorized` after RBAC narrowing.
- [x] Image digest in ECR: `sha256:678e2b30...be45d`.

Made with [Cursor](https://cursor.com)