### PR TITLE
topo: skip creating empty meshnet Topology CR for nodes with no links

### DIFF
--- a/topo/topo.go
+++ b/topo/topo.go
@@ -554,6 +554,19 @@ func (m *Manager) topologySpecs(ctx context.Context) ([]*topologyv1.Topology, er
 	// replace node name with pod name, for peer pod attribute in each link
 	for nodeName, specs := range nodeSpecs {
 		for _, spec := range specs {
+			// Skip Topology CRs with no links: meshnetd's Get RPC
+			// treats a missing `spec.links` field as an error
+			// (`could not find 'Link' array in pod's spec`) and the
+			// CNI plugin then aborts pod sandbox creation with a
+			// misleading `meshnetd provided no HOST_IP` message.
+			// For unconnected nodes we simply don't create the CR;
+			// the meshnet CNI plugin already handles "no Topology
+			// CR" gracefully and falls through to the next plugin
+			// in the chain.
+			if len(spec.Spec.Links) == 0 {
+				log.V(1).Infof("Skipping empty Topology spec for node %s (no links)", nodeName)
+				continue
+			}
 			for l := range spec.Spec.Links {
 				link := &spec.Spec.Links[l]
 				peerSpecs, ok := nodeSpecs[link.PeerPod]


### PR DESCRIPTION
## Summary

When a node has no `Links` in its meshnet `TopologySpec`, `kne` currently still creates a `Topology` CR with `spec: {}`. `meshnetd`'s `Get(podName)` RPC then reads the CR, fails the `unstructured.NestedSlice(... "spec", "links")` lookup with `!found`, logs `could not find 'Link' array in pod's spec` and returns an empty `Pod`. The CNI plugin sees `NodeIp == ""` and aborts the sandbox with the (misleading) error:

```
plugin type="meshnet" failed (add):
  meshnetd provided no HOST_IP address:  or HOST_INTF:
```

Every pod scheduled on a node with no links is then stuck in `FailedCreatePodSandBox` loops until kubelet's 4-minute deadline expires, and the only fix is to manually `kubectl delete topology …` for the offending CRs.

## Fix

Skip CR creation when `len(spec.Spec.Links) == 0`.

The meshnet CNI plugin already handles "no Topology CR for this pod" gracefully (`plugin/meshnet.go cmdAdd` treats `Get` error as `not a topology pod returning` and chains through to the next plugin), so the resulting behaviour is identical to any other non-topology workload on the cluster.

This is a no-op for topologies whose nodes all have links, and substantially improves robustness for sparse / scale-test topologies where some nodes are intentionally isolated.

## Test plan

- [x] `go vet ./topo/...` clean.
- [x] Reproduced end-to-end with a 200-node Alpine topology where ~30% of nodes had no random links — before this change those pods got stuck; after, they come up cleanly without the `kubectl delete topology` workaround.

Made with [Cursor](https://cursor.com)