### PR TITLE
ci: release workflow that attaches kne_cli binaries to GitHub Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,4 @@
+---
 name: Release
 
 # Build kne_cli binaries for linux + darwin (amd64 + arm64) and attach them
@@ -74,7 +75,7 @@ jobs:
             rm -rf "${out_dir}"
           done
 
-          ( cd dist && sha256sum *.tar.gz > SHA256SUMS )
+          ( cd dist && sha256sum -- *.tar.gz > SHA256SUMS )
           ls -lh dist/
           echo "---"
           cat dist/SHA256SUMS

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,91 @@
+name: Release
+
+# Build kne_cli binaries for linux + darwin (amd64 + arm64) and attach them
+# to a GitHub Release.
+#
+# Triggers:
+#   * push of any tag matching v*  -> creates / updates the matching release
+#   * manual dispatch with a tag input -> rebuilds & re-uploads for that tag
+#     (useful for historical tags or when assets need to be regenerated)
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing tag to (re)build a release for (e.g. v0.4.0-dn)'
+        required: true
+
+permissions:
+  contents: write   # required to create / update a GitHub Release
+
+jobs:
+  release:
+    name: Build & publish ${{ github.ref_name }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "ref=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check out tag ${{ steps.tag.outputs.ref }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.tag.outputs.ref }}
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+
+      - name: Build cross-platform binaries
+        env:
+          CGO_ENABLED: '0'
+          TAG: ${{ steps.tag.outputs.ref }}
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          # commit & date come from the checked-out tag so they're stable
+          COMMIT=$(git rev-parse --short HEAD)
+          DATE=$(git show -s --format=%cI HEAD)
+          LDFLAGS="-s -w -X main.version=${TAG} -X main.commit=${COMMIT} -X main.date=${DATE}"
+
+          for combo in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64; do
+            os="${combo%/*}"
+            arch="${combo#*/}"
+            bin="kne"
+            out_dir="dist/kne_${TAG}_${os}_${arch}"
+            mkdir -p "${out_dir}"
+            echo "==> Building ${out_dir}/${bin} (GOOS=${os} GOARCH=${arch})"
+            GOOS="${os}" GOARCH="${arch}" \
+              go build -trimpath -ldflags="${LDFLAGS}" \
+                       -o "${out_dir}/${bin}" ./kne_cli
+            cp LICENSE "${out_dir}/" 2>/dev/null || true
+            cp README.md "${out_dir}/" 2>/dev/null || true
+            tar -C dist -czf "dist/kne_${TAG}_${os}_${arch}.tar.gz" \
+              "$(basename "${out_dir}")"
+            rm -rf "${out_dir}"
+          done
+
+          ( cd dist && sha256sum *.tar.gz > SHA256SUMS )
+          ls -lh dist/
+          echo "---"
+          cat dist/SHA256SUMS
+
+      - name: Create / update GitHub Release with assets
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.ref }}
+          name: ${{ steps.tag.outputs.ref }}
+          generate_release_notes: true
+          fail_on_unmatched_files: true
+          files: |
+            dist/*.tar.gz
+            dist/SHA256SUMS

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ x/wire/file/server/server
 x/wire/intf/client/client
 x/wire/intf/server/server
 x/wire/forward/forward
+dist/

--- a/Makefile
+++ b/Makefile
@@ -62,5 +62,5 @@ dist:
 	   tar -C dist -czf "dist/kne_$(TAG)_$${os}_$${arch}.tar.gz" "$$(basename $$out)"; \
 	   rm -rf "$$out"; \
 	 done; \
-	 ( cd dist && sha256sum *.tar.gz > SHA256SUMS )
+	 ( cd dist && sha256sum -- *.tar.gz > SHA256SUMS )
 	@ls -lh dist/

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,9 @@ KNE_CLI_BIN := kne
 INSTALL_DIR := /usr/local/bin
 
 COMMIT := $(shell git describe --dirty --always)
-TAG := $(shell git describe --tags --abbrev=0 || echo latest)
+# Allow overriding TAG via env (e.g. `TAG=v0.4.0-dn make dist`) so release
+# builds aren't pinned to whatever `git describe` happens to return.
+TAG ?= $(shell git describe --tags --abbrev=0 || echo latest)
 
 
 include .mk/kind.mk
@@ -38,3 +40,27 @@ build:
 ## Install kne cli binary to user's local bin dir
 install: build
 	sudo mv $(KNE_CLI_BIN) $(INSTALL_DIR)
+
+.PHONY: dist
+## Cross-build kne_cli for linux+darwin (amd64+arm64) into ./dist
+## Mirrors what .github/workflows/release.yml does so releases are reproducible locally.
+dist:
+	@rm -rf dist && mkdir -p dist
+	@COMMIT=$$(git rev-parse --short HEAD); \
+	 DATE=$$(git show -s --format=%cI HEAD); \
+	 LDFLAGS="-s -w -X main.version=$(TAG) -X main.commit=$$COMMIT -X main.date=$$DATE"; \
+	 for combo in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64; do \
+	   os=$${combo%/*}; arch=$${combo#*/}; \
+	   out=dist/kne_$(TAG)_$${os}_$${arch}; \
+	   mkdir -p "$$out"; \
+	   echo "==> $$out (GOOS=$$os GOARCH=$$arch)"; \
+	   CGO_ENABLED=0 GOOS=$$os GOARCH=$$arch \
+	     go build -trimpath -ldflags="$$LDFLAGS" \
+	              -o "$$out/$(KNE_CLI_BIN)" ./kne_cli; \
+	   cp LICENSE "$$out/" 2>/dev/null || true; \
+	   cp README.md "$$out/" 2>/dev/null || true; \
+	   tar -C dist -czf "dist/kne_$(TAG)_$${os}_$${arch}.tar.gz" "$$(basename $$out)"; \
+	   rm -rf "$$out"; \
+	 done; \
+	 ( cd dist && sha256sum *.tar.gz > SHA256SUMS )
+	@ls -lh dist/


### PR DESCRIPTION
## Summary

Currently the drivenets fork of kne has no `gh release` artifacts — users have to clone + `go build` to get a working `kne` binary. Adds a release workflow + a `make dist` target so:

- pushing a `v*` git tag automatically produces a GitHub Release with cross-compiled binaries for **linux/{amd64,arm64}** and **darwin/{amd64,arm64}**
- the same packaging can be reproduced locally with `TAG=v0.4.0-dn make dist`

## What's in each release

Per platform (`{os}_{arch}`):

```
kne_<TAG>_<os>_<arch>.tar.gz
  ├── kne                     # statically linked, stripped, trimpath
  ├── LICENSE
  └── README.md
SHA256SUMS                    # one line per tarball
```

Binaries are built with:

```
CGO_ENABLED=0 GOOS=<os> GOARCH=<arch> \
  go build -trimpath \
           -ldflags='-s -w -X main.version=<TAG> -X main.commit=<sha> -X main.date=<iso>' \
           ./kne_cli
```

## Trigger model

- `push` of any tag matching `v*` → creates / updates the release with that tag
- `workflow_dispatch` with a `tag` input → rebuilds for an existing tag (useful for re-issuing assets without retagging)

`generate_release_notes: true` so GitHub auto-fills the body from PR titles since the previous tag.

## Test plan

- [x] `TAG=v0.4.0-dn make dist` locally → 4 tarballs produced (~14–16 MB each)
- [x] Extracted `kne_v0.4.0-dn_linux_amd64.tar.gz`, ran the embedded `kne help` — output is the standard help text
- [x] `file dist/.../kne` confirms statically linked, stripped x86-64 ELF
- [x] SHA256SUMS contains all 4 tarballs

## Follow-up

Once merged, tagging `v0.4.0-dn` on `main` will produce the first drivenets-fork release. That tag is suggested because the fork has accumulated breaking-ish changes vs upstream `v0.3.1` (CVE deps bumps, narrowed RBAC equivalents, empty-ConfigMap fix, skip-empty-Topology fix).

Made with [Cursor](https://cursor.com)